### PR TITLE
Untangle megacities - Iraq

### DIFF
--- a/data/859/031/59/85903159.geojson
+++ b/data/859/031/59/85903159.geojson
@@ -39,9 +39,6 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0628\u0635\u0631\u0629 \u0627\u0644\u0642\u062f\u064a\u0645\u0629"
     ],
-    "name:eng_x_colloquial":[
-        ""
-    ],
     "name:und_x_variant":[
         "Al Ba\u015frat al Qad\u012bmah"
     ],
@@ -162,7 +159,6 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
-    "src:population":"geonames",
     "wof:belongsto":[
         85672453,
         102191569,
@@ -191,15 +187,11 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714121,
-    "wof:megacity":1,
+    "wof:lastmodified":1578079595,
     "wof:name":"Al Ba\u015frah Al Qad\u012bmah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
-    "wof:population":2015483,
-    "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-iq",
-    "wof:scale":4,
     "wof:superseded_by":[],
     "wof:supersedes":[
         1126065701


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#701

This PR fixes an issue with wof:megacity properties in Iraq. One neighbourhood was accidentally given the property flag and population data, which seems sourced from GeoNames. I was hoping to swap the `wof:megacity` property to an existing locality, but this neighbourhood is in Basra, Iraq and Basra doesn't look to be a "megacity".

I can rework the property flag on localities in Iraq as a follow-up, but this should be merged now.

No PIP work required, can be merged as-is.