### PR TITLE
geom_alt props

### DIFF
--- a/data/421/169/765/421169765.geojson
+++ b/data/421/169/765/421169765.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459008823,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfd64834de3c3cf7271741be30f42cd7",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421169765,
-    "wof:lastmodified":1566714961,
+    "wof:lastmodified":1582314010,
     "wof:name":"Khalis",
     "wof:parent_id":85672481,
     "wof:placetype":"county",

--- a/data/421/172/357/421172357.geojson
+++ b/data/421/172/357/421172357.geojson
@@ -268,6 +268,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459008937,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"540e4d160b202d50be216c6a47213c6b",
     "wof:hierarchy":[
         {
@@ -278,7 +281,7 @@
         }
     ],
     "wof:id":421172357,
-    "wof:lastmodified":1566714963,
+    "wof:lastmodified":1582314011,
     "wof:name":"Nassriya",
     "wof:parent_id":85672463,
     "wof:placetype":"county",

--- a/data/421/172/365/421172365.geojson
+++ b/data/421/172/365/421172365.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459008937,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7fc78ddce50864db65994c91998f4635",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421172365,
-    "wof:lastmodified":1566714963,
+    "wof:lastmodified":1582314011,
     "wof:name":"Shikhan",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/421/172/849/421172849.geojson
+++ b/data/421/172/849/421172849.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459008956,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6fb754b96aab8cb29674ae57ea476e79",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421172849,
-    "wof:lastmodified":1566714964,
+    "wof:lastmodified":1582314011,
     "wof:name":"Musayab",
     "wof:parent_id":85672491,
     "wof:placetype":"county",

--- a/data/421/177/881/421177881.geojson
+++ b/data/421/177/881/421177881.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009163,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2200ab2d3db1971ec2ff697430538469",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":421177881,
-    "wof:lastmodified":1566714969,
+    "wof:lastmodified":1582314012,
     "wof:name":"Heet",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/421/178/393/421178393.geojson
+++ b/data/421/178/393/421178393.geojson
@@ -752,6 +752,9 @@
     ],
     "wof:country":"IQ",
     "wof:created":1459009180,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c66882d456815289d0a50039b58ecea",
     "wof:hierarchy":[
         {
@@ -763,7 +766,7 @@
         }
     ],
     "wof:id":421178393,
-    "wof:lastmodified":1566714969,
+    "wof:lastmodified":1582314012,
     "wof:name":"\u0628\u063a\u062f\u0627\u062f",
     "wof:parent_id":1108562785,
     "wof:placetype":"locality",

--- a/data/421/178/933/421178933.geojson
+++ b/data/421/178/933/421178933.geojson
@@ -210,6 +210,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009198,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac4b86166670d262bbd9c77a5076db4e",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":421178933,
-    "wof:lastmodified":1566714970,
+    "wof:lastmodified":1582314012,
     "wof:name":"Ramadi",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/421/180/939/421180939.geojson
+++ b/data/421/180/939/421180939.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009276,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b4bd7e80f843165801683a93f7724bf",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421180939,
-    "wof:lastmodified":1566714963,
+    "wof:lastmodified":1582314011,
     "wof:name":"Balad",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/421/181/959/421181959.geojson
+++ b/data/421/181/959/421181959.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009313,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea055060e5f903ae39c6ef678fb42ecc",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421181959,
-    "wof:lastmodified":1566714965,
+    "wof:lastmodified":1582314011,
     "wof:name":"Diwaniya",
     "wof:parent_id":85672459,
     "wof:placetype":"county",

--- a/data/421/182/249/421182249.geojson
+++ b/data/421/182/249/421182249.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009323,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c2de2fe8359412fb4eb0de4a217cc69",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421182249,
-    "wof:lastmodified":1566714970,
+    "wof:lastmodified":1582314012,
     "wof:name":"Amedi",
     "wof:parent_id":85672417,
     "wof:placetype":"county",

--- a/data/421/183/885/421183885.geojson
+++ b/data/421/183/885/421183885.geojson
@@ -251,6 +251,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009390,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ecea80d5a8fdc472f9d51b84ada2e47",
     "wof:hierarchy":[
         {
@@ -261,7 +264,7 @@
         }
     ],
     "wof:id":421183885,
-    "wof:lastmodified":1566714969,
+    "wof:lastmodified":1582314012,
     "wof:name":"Halabja",
     "wof:parent_id":1108804835,
     "wof:placetype":"county",

--- a/data/421/184/253/421184253.geojson
+++ b/data/421/184/253/421184253.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009405,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"471b16f86912bdbf84c421bcbfda18fd",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421184253,
-    "wof:lastmodified":1566714968,
+    "wof:lastmodified":1582314012,
     "wof:name":"Muqdadiya",
     "wof:parent_id":85672481,
     "wof:placetype":"county",

--- a/data/421/184/255/421184255.geojson
+++ b/data/421/184/255/421184255.geojson
@@ -263,6 +263,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009405,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"817c341bf3572067ba899fc5bda67b96",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
         }
     ],
     "wof:id":421184255,
-    "wof:lastmodified":1566714968,
+    "wof:lastmodified":1582314012,
     "wof:name":"Najaf",
     "wof:parent_id":85672439,
     "wof:placetype":"county",

--- a/data/421/184/257/421184257.geojson
+++ b/data/421/184/257/421184257.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009405,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f063de8409977445f421903b710f185",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421184257,
-    "wof:lastmodified":1566714968,
+    "wof:lastmodified":1582314011,
     "wof:name":"Abu Ghraib",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/421/186/243/421186243.geojson
+++ b/data/421/186/243/421186243.geojson
@@ -272,6 +272,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009474,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"50b92518308fd325c85069f0cb945a0c",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         }
     ],
     "wof:id":421186243,
-    "wof:lastmodified":1566714964,
+    "wof:lastmodified":1582314011,
     "wof:name":"Tikrit",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/421/186/449/421186449.geojson
+++ b/data/421/186/449/421186449.geojson
@@ -179,6 +179,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009481,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7119b3eb2be230dcb2b6e5b08ee31656",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":421186449,
-    "wof:lastmodified":1566714964,
+    "wof:lastmodified":1582314011,
     "wof:name":"Sinjar",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/421/186/459/421186459.geojson
+++ b/data/421/186/459/421186459.geojson
@@ -189,6 +189,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009481,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08bbe2d307dba28f31312bba000e772b",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":421186459,
-    "wof:lastmodified":1566714964,
+    "wof:lastmodified":1582314011,
     "wof:name":"Kut",
     "wof:parent_id":85672473,
     "wof:placetype":"county",

--- a/data/421/186/463/421186463.geojson
+++ b/data/421/186/463/421186463.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009482,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"475d1632f51d67c25a73a8c72aa4d80e",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":421186463,
-    "wof:lastmodified":1566714964,
+    "wof:lastmodified":1582314011,
     "wof:name":"Akre",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/421/188/909/421188909.geojson
+++ b/data/421/188/909/421188909.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009587,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"118cb6e43650dbd0ab24c03b801c59ef",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421188909,
-    "wof:lastmodified":1566714963,
+    "wof:lastmodified":1582314011,
     "wof:name":"Mahawil",
     "wof:parent_id":85672491,
     "wof:placetype":"county",

--- a/data/421/189/307/421189307.geojson
+++ b/data/421/189/307/421189307.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009617,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2320693bc4b0438b3724694925a8afc3",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":421189307,
-    "wof:lastmodified":1566714963,
+    "wof:lastmodified":1582314011,
     "wof:name":"Mahmoudiya",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/421/191/407/421191407.geojson
+++ b/data/421/191/407/421191407.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009691,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d025d40b2d1da6216b7d533d4e61368",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421191407,
-    "wof:lastmodified":1566714966,
+    "wof:lastmodified":1582314011,
     "wof:name":"Falluja",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/421/194/967/421194967.geojson
+++ b/data/421/194/967/421194967.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009826,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de1f65c6c6c35f8d5c0439de748cc99e",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421194967,
-    "wof:lastmodified":1566714961,
+    "wof:lastmodified":1582314010,
     "wof:name":"Kerbala",
     "wof:parent_id":85672443,
     "wof:placetype":"county",

--- a/data/421/197/843/421197843.geojson
+++ b/data/421/197/843/421197843.geojson
@@ -249,6 +249,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009927,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"a73471372123c08aa5e705dfce0ed758",
     "wof:hierarchy":[
         {
@@ -260,7 +263,7 @@
         }
     ],
     "wof:id":421197843,
-    "wof:lastmodified":1566714967,
+    "wof:lastmodified":1582314011,
     "wof:name":"Kut Al Hai",
     "wof:parent_id":1108562685,
     "wof:placetype":"locality",

--- a/data/421/199/293/421199293.geojson
+++ b/data/421/199/293/421199293.geojson
@@ -333,6 +333,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009984,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13056b2d563260f36efad892fe330db6",
     "wof:hierarchy":[
         {
@@ -343,7 +346,7 @@
         }
     ],
     "wof:id":421199293,
-    "wof:lastmodified":1566714967,
+    "wof:lastmodified":1582314011,
     "wof:name":"Kirkuk",
     "wof:parent_id":1108804831,
     "wof:placetype":"county",

--- a/data/421/200/817/421200817.geojson
+++ b/data/421/200/817/421200817.geojson
@@ -361,6 +361,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459010042,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d85fc588d001e19f6de008a8b17aa914",
     "wof:hierarchy":[
         {
@@ -371,7 +374,7 @@
         }
     ],
     "wof:id":421200817,
-    "wof:lastmodified":1566714967,
+    "wof:lastmodified":1582314011,
     "wof:name":"Erbil",
     "wof:parent_id":85672425,
     "wof:placetype":"county",

--- a/data/421/204/025/421204025.geojson
+++ b/data/421/204/025/421204025.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459010171,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d5523833c0e442ed4abf4a0a679340d",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421204025,
-    "wof:lastmodified":1566714962,
+    "wof:lastmodified":1582314011,
     "wof:name":"Dahuk",
     "wof:parent_id":85672417,
     "wof:placetype":"county",

--- a/data/421/205/333/421205333.geojson
+++ b/data/421/205/333/421205333.geojson
@@ -245,6 +245,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1459010221,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b5c15a6ad4335fcf7cd2ceff556fd20",
     "wof:hierarchy":[
         {
@@ -255,7 +258,7 @@
         }
     ],
     "wof:id":421205333,
-    "wof:lastmodified":1566714962,
+    "wof:lastmodified":1582314011,
     "wof:name":"Samawa",
     "wof:parent_id":85672455,
     "wof:placetype":"county",

--- a/data/856/321/91/85632191.geojson
+++ b/data/856/321/91/85632191.geojson
@@ -1023,6 +1023,8 @@
     "src:geom":"meso",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
+        "meso",
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1078,6 +1080,12 @@
     },
     "wof:country":"IQ",
     "wof:country_alpha3":"IRQ",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso-reversegeo",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e64d10f1f3d9fbbb2ed2db1ba78cda2a",
     "wof:hierarchy":[
         {
@@ -1093,7 +1101,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714127,
+    "wof:lastmodified":1582313991,
     "wof:name":"Iraq",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/321/91/85632191.geojson
+++ b/data/856/321/91/85632191.geojson
@@ -1023,7 +1023,6 @@
     "src:geom":"meso",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso",
         "quattroshapes"
     ],
@@ -1101,7 +1100,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1582313991,
+    "wof:lastmodified":1583200684,
     "wof:name":"Iraq",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/724/17/85672417.geojson
+++ b/data/856/724/17/85672417.geojson
@@ -326,6 +326,9 @@
         "wk:page":"Dohuk Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4da94c04e9f6c8069cd705988861b68c",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714124,
+    "wof:lastmodified":1582313989,
     "wof:name":"Dihok",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/724/25/85672425.geojson
+++ b/data/856/724/25/85672425.geojson
@@ -328,6 +328,9 @@
         "wk:page":"Erbil Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3837b0fa7ec4f4c6791a154a27ef4b6b",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714126,
+    "wof:lastmodified":1582313991,
     "wof:name":"Arbil",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/724/29/85672429.geojson
+++ b/data/856/724/29/85672429.geojson
@@ -323,6 +323,9 @@
         "wk:page":"Nineveh Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b17cd244995ef39266ac8eb2ae8c3002",
     "wof:hierarchy":[
         {
@@ -339,7 +342,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714123,
+    "wof:lastmodified":1582313989,
     "wof:name":"Ninawa",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/35/85672435.geojson
+++ b/data/856/724/35/85672435.geojson
@@ -154,6 +154,9 @@
         "unlc:id":"IQ-SD"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9f791629e97d716e0c464555be28b66",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714123,
+    "wof:lastmodified":1582313989,
     "wof:name":"Sala ad-Din",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/39/85672439.geojson
+++ b/data/856/724/39/85672439.geojson
@@ -319,6 +319,9 @@
         "wk:page":"Najaf Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3e2c9b411b39bc4817ebcb60ab54361",
     "wof:hierarchy":[
         {
@@ -335,7 +338,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714125,
+    "wof:lastmodified":1582313990,
     "wof:name":"An-Najaf",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/43/85672443.geojson
+++ b/data/856/724/43/85672443.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Karbala Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2cb993bcba3bc83e07ddafe3e90ab712",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714125,
+    "wof:lastmodified":1582313990,
     "wof:name":"Karbala'",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/47/85672447.geojson
+++ b/data/856/724/47/85672447.geojson
@@ -720,6 +720,9 @@
         421178393
     ],
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a8918cb9dc64806d933fffe9b48dab0",
     "wof:hierarchy":[
         {
@@ -736,7 +739,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714126,
+    "wof:lastmodified":1582313990,
     "wof:name":"Baghdad",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/53/85672453.geojson
+++ b/data/856/724/53/85672453.geojson
@@ -152,6 +152,9 @@
         "unlc:id":"IQ-BA"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eced212ee1f87e6619bfd50978929f3e",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714125,
+    "wof:lastmodified":1582313990,
     "wof:name":"Al-Basrah",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/55/85672455.geojson
+++ b/data/856/724/55/85672455.geojson
@@ -274,6 +274,9 @@
         "wk:page":"Muthanna Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"889798b8276d43944ed1af97a180ee6e",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714126,
+    "wof:lastmodified":1582313990,
     "wof:name":"Al-Muthannia",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/59/85672459.geojson
+++ b/data/856/724/59/85672459.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Al-Q\u0101disiyyah Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bdd771f7c3c83358825fb84ad7486cdf",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714122,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al-Qadisiyah",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/63/85672463.geojson
+++ b/data/856/724/63/85672463.geojson
@@ -253,6 +253,9 @@
         "wk:page":"Dhi Qar Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"225503e75c0b95483f45aab85de9f3e4",
     "wof:hierarchy":[
         {
@@ -269,7 +272,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714126,
+    "wof:lastmodified":1582313990,
     "wof:name":"Dhi-Qar",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/69/85672469.geojson
+++ b/data/856/724/69/85672469.geojson
@@ -314,6 +314,9 @@
         "wk:page":"Maysan Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b218f072a42b03186cf782ad97c460b8",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714123,
+    "wof:lastmodified":1582313989,
     "wof:name":"Maysan",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/73/85672473.geojson
+++ b/data/856/724/73/85672473.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Wasit Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c073ccf787dabe6a96682519f94f0d0",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714124,
+    "wof:lastmodified":1582313989,
     "wof:name":"Wasit",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/75/85672475.geojson
+++ b/data/856/724/75/85672475.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Sulaymaniyah Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a934ee3708b0a08c66738cdd1d3e718",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714124,
+    "wof:lastmodified":1582313990,
     "wof:name":"As-Sulaymaniyah",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/724/81/85672481.geojson
+++ b/data/856/724/81/85672481.geojson
@@ -317,6 +317,9 @@
         "wk:page":"Diyala Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ecd047a60754a37760b074d40d28e49",
     "wof:hierarchy":[
         {
@@ -333,7 +336,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714125,
+    "wof:lastmodified":1582313990,
     "wof:name":"Diyala",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/83/85672483.geojson
+++ b/data/856/724/83/85672483.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Al Anbar Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3225c8f38be2ef988a238ff5e669c215",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714126,
+    "wof:lastmodified":1582313990,
     "wof:name":"Al-Anbar",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/91/85672491.geojson
+++ b/data/856/724/91/85672491.geojson
@@ -326,6 +326,9 @@
         "wk:page":"Babil Governorate"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"44ad86eecc87277a5677edaeac304982",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714125,
+    "wof:lastmodified":1582313990,
     "wof:name":"Babil",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/859/031/57/85903157.geojson
+++ b/data/859/031/57/85903157.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1120223
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5baa6d7feef9b647a2522fafb1278d55",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714121,
+    "wof:lastmodified":1582313988,
     "wof:name":"\u2018abb\u0101s H\u0327ayy Al",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/59/85903159.geojson
+++ b/data/859/031/59/85903159.geojson
@@ -172,6 +172,9 @@
         "qs_pg:id":124557
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7e66615112e2a4a71068d6ac5089453",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1578079595,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al Ba\u015frah Al Qad\u012bmah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/61/85903161.geojson
+++ b/data/859/031/61/85903161.geojson
@@ -78,6 +78,9 @@
         "gp:id":1970805
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eaa6bf0e5604f7efe5969c4846854746",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714121,
+    "wof:lastmodified":1582313987,
     "wof:name":"Al Fay\u015fal\u012byah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/63/85903163.geojson
+++ b/data/859/031/63/85903163.geojson
@@ -69,6 +69,9 @@
         "qs_pg:id":1120228
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94139ded25cb7a12363de3d99d0970ad",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714122,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al Firdaws",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/65/85903165.geojson
+++ b/data/859/031/65/85903165.geojson
@@ -75,6 +75,9 @@
         "gp:id":1970880
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84a9275e067d610b3bf33a9ae07f214f",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714122,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al H\u0327\u0101rith\u012byah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/67/85903167.geojson
+++ b/data/859/031/67/85903167.geojson
@@ -79,6 +79,9 @@
         "qs:id":910625
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"336cd5e2974db254145daebf4be0e24d",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1534379347,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al Idr\u012bs\u012b",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/69/85903169.geojson
+++ b/data/859/031/69/85903169.geojson
@@ -90,6 +90,9 @@
         "qs_pg:id":239246
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a5dd30a7265132ba12e4eb8cb306282",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714121,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al J\u0101mi\u2019ah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/71/85903171.geojson
+++ b/data/859/031/71/85903171.geojson
@@ -102,6 +102,9 @@
         "qs_pg:id":44646
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"afc18110619d5e4e0e8e088f50a73d3c",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714122,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al Jaz\u00e5'ir",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/75/85903175.geojson
+++ b/data/859/031/75/85903175.geojson
@@ -79,6 +79,9 @@
         "qs:id":44647
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5db92b9865266b6ac292b83dddbe2ab7",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1534379347,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al Jaz\u012brah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/77/85903177.geojson
+++ b/data/859/031/77/85903177.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Karkh"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98ffd776d825db7d491fe19f979d9dc7",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714122,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al Karkh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/79/85903179.geojson
+++ b/data/859/031/79/85903179.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Kadhimiya"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7fb5f0a996687fa2fdbaeeb9619cdce3",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1561767075,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al K\u0101z\u0327im\u012byah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/81/85903181.geojson
+++ b/data/859/031/81/85903181.geojson
@@ -72,6 +72,9 @@
         "gp:id":1971163
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5704b3caeb40acb837b3c57c6d5d39fa",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714121,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al Wah\u0327dah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/83/85903183.geojson
+++ b/data/859/031/83/85903183.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q4703327"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5803f439efc8b79470ff611e305d557c",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714122,
+    "wof:lastmodified":1582313988,
     "wof:name":"Al Wash\u00e5sh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/85/85903185.geojson
+++ b/data/859/031/85/85903185.geojson
@@ -69,6 +69,9 @@
         "qs_pg:id":1002945
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a651c22d2a3d43a496116345323ecb7",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714122,
+    "wof:lastmodified":1582313988,
     "wof:name":"Alawi Al-Hilla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/87/85903187.geojson
+++ b/data/859/031/87/85903187.geojson
@@ -69,6 +69,9 @@
         "qs_pg:id":1002946
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d0f5b29937b756e60ec4a46b76e4d57",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714121,
+    "wof:lastmodified":1582313988,
     "wof:name":"Alwiya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/89/85903189.geojson
+++ b/data/859/031/89/85903189.geojson
@@ -81,6 +81,9 @@
         "qs_pg:id":988706
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d759215d9c98539ad8b71306c297d65d",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714121,
+    "wof:lastmodified":1582313988,
     "wof:name":"Ar Ra\u015f\u0101fah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/93/85903193.geojson
+++ b/data/859/031/93/85903193.geojson
@@ -133,6 +133,9 @@
         "wd:id":"Q672905"
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8cadc374779b01f44f3c49407dbfe43",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714121,
+    "wof:lastmodified":1582313988,
     "wof:name":"Arrapha",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/95/85903195.geojson
+++ b/data/859/031/95/85903195.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":900319
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d81fdcc5f25962b250d60ed5e3e0545b",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714121,
+    "wof:lastmodified":1582313987,
     "wof:name":"A\u015f \u015e\u0101lih\u0327\u012byah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/97/85903197.geojson
+++ b/data/859/031/97/85903197.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":1120273
     },
     "wof:country":"IQ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"24f8f39eba16a00b16ba59f6d77d6163",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566714122,
+    "wof:lastmodified":1582313988,
     "wof:name":"Q\u0101\u0163irkh\u0101nah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/445/289/890445289.geojson
+++ b/data/890/445/289/890445289.geojson
@@ -182,6 +182,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1469052504,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a16f4e6a20a5ad2c1f2953044d5bc9e3",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":890445289,
-    "wof:lastmodified":1566714972,
+    "wof:lastmodified":1582314012,
     "wof:name":"Zakho",
     "wof:parent_id":85672417,
     "wof:placetype":"county",

--- a/data/890/445/493/890445493.geojson
+++ b/data/890/445/493/890445493.geojson
@@ -71,6 +71,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1469052511,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"843ed930e3a52b0cce147d15e147f33e",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890445493,
-    "wof:lastmodified":1566714972,
+    "wof:lastmodified":1582314012,
     "wof:name":"Koisnjaq",
     "wof:parent_id":85672425,
     "wof:placetype":"county",

--- a/data/890/445/495/890445495.geojson
+++ b/data/890/445/495/890445495.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1469052512,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7bf504eec48364a60023c99e34e45c7d",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":890445495,
-    "wof:lastmodified":1566714972,
+    "wof:lastmodified":1582314012,
     "wof:name":"Soran",
     "wof:parent_id":85672425,
     "wof:placetype":"county",

--- a/data/890/449/807/890449807.geojson
+++ b/data/890/449/807/890449807.geojson
@@ -84,6 +84,9 @@
     },
     "wof:country":"IQ",
     "wof:created":1469052711,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c755a4c1fdf736441725423dae43e3fe",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":890449807,
-    "wof:lastmodified":1566714971,
+    "wof:lastmodified":1582314012,
     "wof:name":"N\u0101\u1e29\u012byat Saddat al Hind\u012byah",
     "wof:parent_id":421172849,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.