### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/180/941/421180941.geojson
+++ b/data/421/180/941/421180941.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421180941,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Baghdad",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/421/180/941/421180941.geojson
+++ b/data/421/180/941/421180941.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u063a\u062f\u0627\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Baghdad"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009276,
-    "wof:geomhash":"806c44764192d5394cd14d56471daa9d",
+    "wof:geomhash":"75396df15595ef13641635a9248306d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421180941,
-    "wof:lastmodified":1474052715,
-    "wof:name":"\u0628\u063a\u062f\u0627\u062f",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Baghdad",
     "wof:parent_id":85672447,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/180/943/421180943.geojson
+++ b/data/421/180/943/421180943.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421180943,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423087,
     "wof:name":"Basra",
     "wof:parent_id":85672453,
     "wof:placetype":"county",

--- a/data/421/180/943/421180943.geojson
+++ b/data/421/180/943/421180943.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u0635\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Basra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009276,
-    "wof:geomhash":"1eefd800f409b51ac74cf511a5cc198c",
+    "wof:geomhash":"49ca9f9f4db99ce452f0dcc83b1ad20d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421180943,
-    "wof:lastmodified":1474052711,
-    "wof:name":"\u0627\u0644\u0628\u0635\u0631\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Basra",
     "wof:parent_id":85672453,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/184/429/421184429.geojson
+++ b/data/421/184/429/421184429.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u0645\u0627\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Amarah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184429,
-    "wof:lastmodified":1566714968,
-    "wof:name":"\u0627\u0644\u0639\u0645\u0627\u0631\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Amarah",
     "wof:parent_id":1108562681,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/184/429/421184429.geojson
+++ b/data/421/184/429/421184429.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        85672469,
-        1108562681
+        1108562681,
+        85672469
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184429,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Amarah",
     "wof:parent_id":1108562681,
     "wof:placetype":"locality",

--- a/data/421/185/695/421185695.geojson
+++ b/data/421/185/695/421185695.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        85672447,
-        1108562793
+        1108562793,
+        85672447
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185695,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423091,
     "wof:name":"Petra",
     "wof:parent_id":1108562793,
     "wof:placetype":"locality",

--- a/data/421/185/695/421185695.geojson
+++ b/data/421/185/695/421185695.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u062a\u0631\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Petra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185695,
-    "wof:lastmodified":1566714970,
-    "wof:name":"\u0628\u062a\u0631\u0627",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Petra",
     "wof:parent_id":1108562793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/186/461/421186461.geojson
+++ b/data/421/186/461/421186461.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421186461,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423091,
     "wof:name":"Mosul",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/421/186/461/421186461.geojson
+++ b/data/421/186/461/421186461.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0648\u0635\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Mosul"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009481,
-    "wof:geomhash":"86deaf016c725f94e6b65635806370c9",
+    "wof:geomhash":"4f58ff9c27650eee64c30624fdee6691",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421186461,
-    "wof:lastmodified":1474052701,
-    "wof:name":"\u0645\u0648\u0635\u0644",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Mosul",
     "wof:parent_id":85672429,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/190/731/421190731.geojson
+++ b/data/421/190/731/421190731.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        85672483,
-        421178933
+        421178933,
+        85672483
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190731,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Habbaniyah",
     "wof:parent_id":421178933,
     "wof:placetype":"locality",

--- a/data/421/190/731/421190731.geojson
+++ b/data/421/190/731/421190731.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062d\u0628\u0627\u0646\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Habbaniyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190731,
-    "wof:lastmodified":1566714966,
-    "wof:name":"\u0627\u0644\u062d\u0628\u0627\u0646\u064a\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Habbaniyah",
     "wof:parent_id":421178933,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/190/735/421190735.geojson
+++ b/data/421/190/735/421190735.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        85672429,
-        1108562635
+        1108562635,
+        85672429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190735,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tal Afar",
     "wof:parent_id":1108562635,
     "wof:placetype":"locality",

--- a/data/421/190/735/421190735.geojson
+++ b/data/421/190/735/421190735.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0644\u0639\u0641\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Tal Afar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190735,
-    "wof:lastmodified":1566714966,
-    "wof:name":"\u062a\u0644\u0639\u0641\u0631",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tal Afar",
     "wof:parent_id":1108562635,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/190/745/421190745.geojson
+++ b/data/421/190/745/421190745.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"46.245523,31.0363145,46.245523,31.0363145",
+    "geom:bbox":"46.245523,31.036314,46.245523,31.036314",
     "geom:latitude":31.036314,
     "geom:longitude":46.245523,
     "iso:country":"IQ",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        85672463,
-        421172357
+        421172357,
+        85672463
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"IQ",
     "wof:created":1459009667,
-    "wof:geomhash":"90a0b7af734c1e801e7dcd7f571b7ee2",
+    "wof:geomhash":"f224f8fcf4845422baf4be0afa861373",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190745,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"An Nasiriyah",
     "wof:parent_id":421172357,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     46.245523,
-    31.0363145,
+    31.036314,
     46.245523,
-    31.0363145
+    31.036314
 ],
-  "geometry": {"coordinates":[46.245523,31.0363145],"type":"Point"}
+  "geometry": {"coordinates":[46.245523,31.036314],"type":"Point"}
 }

--- a/data/421/190/745/421190745.geojson
+++ b/data/421/190/745/421190745.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0646\u0627\u0635\u0631\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "An Nasiriyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190745,
-    "wof:lastmodified":1566714966,
-    "wof:name":"\u0627\u0644\u0646\u0627\u0635\u0631\u064a\u0629",
+    "wof:lastmodified":1601068393,
+    "wof:name":"An Nasiriyah",
     "wof:parent_id":421172357,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/190/747/421190747.geojson
+++ b/data/421/190/747/421190747.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u0645\u0627\u0648\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Al Samawah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190747,
-    "wof:lastmodified":1566714966,
-    "wof:name":"\u0627\u0644\u0633\u0645\u0627\u0648\u0627",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Samawah",
     "wof:parent_id":421205333,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/190/747/421190747.geojson
+++ b/data/421/190/747/421190747.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        85672455,
-        421205333
+        421205333,
+        85672455
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190747,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Samawah",
     "wof:parent_id":421205333,
     "wof:placetype":"locality",

--- a/data/421/190/751/421190751.geojson
+++ b/data/421/190/751/421190751.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u0631\u0643\u0648\u0643"
+    ],
+    "name:eng_x_preferred":[
+        "Kirkuk"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190751,
-    "wof:lastmodified":1566714966,
-    "wof:name":"\u0643\u0631\u0643\u0648\u0643",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Kirkuk",
     "wof:parent_id":421199293,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/190/751/421190751.geojson
+++ b/data/421/190/751/421190751.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        1108804831,
-        421199293
+        421199293,
+        1108804831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190751,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Kirkuk",
     "wof:parent_id":421199293,
     "wof:placetype":"locality",

--- a/data/421/190/759/421190759.geojson
+++ b/data/421/190/759/421190759.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0643\u0631\u064a\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Tikrit"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190759,
-    "wof:lastmodified":1566714966,
-    "wof:name":"\u062a\u0643\u0631\u064a\u062a",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tikrit",
     "wof:parent_id":421186243,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",

--- a/data/421/190/759/421190759.geojson
+++ b/data/421/190/759/421190759.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        85672435,
-        421186243
+        421186243,
+        85672435
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190759,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tikrit",
     "wof:parent_id":421186243,
     "wof:placetype":"locality",

--- a/data/890/449/715/890449715.geojson
+++ b/data/890/449/715/890449715.geojson
@@ -38,8 +38,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        85672425,
-        421200817
+        421200817,
+        85672425
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -59,7 +59,7 @@
         }
     ],
     "wof:id":890449715,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423088,
     "wof:name":"Erbil",
     "wof:parent_id":421200817,
     "wof:placetype":"locality",

--- a/data/890/449/715/890449715.geojson
+++ b/data/890/449/715/890449715.geojson
@@ -18,6 +18,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:ara_x_preferred":[
+        "\u0627\u0631\u0628\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Erbil"
+    ],
     "qs:name":"\u0627\u0631\u0628\u064a\u0644",
     "qs:name_adm0":"Iraq",
     "qs:name_adm1":"Arbil",
@@ -53,8 +59,8 @@
         }
     ],
     "wof:id":890449715,
-    "wof:lastmodified":1566714971,
-    "wof:name":"\u0627\u0631\u0628\u064a\u0644",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Erbil",
     "wof:parent_id":421200817,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.