### PR TITLE
Update locality name

### DIFF
--- a/data/130/969/516/1/1309695161.geojson
+++ b/data/130/969/516/1/1309695161.geojson
@@ -28,10 +28,16 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
-    "name:ara_x_preferred":[
+    "name:ara_x_variant":[
         "\u0647\u0632\u0627\u0631 \u062c\u0641\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Hizarjoot"
+    ],
+    "name:eng_x_variant":[
+        "Hizar Jift"
     ],
     "name:kur_x_preferred":[
         "Hezar"
@@ -52,8 +58,8 @@
     "wof:belongsto":[
         102191569,
         85632191,
-        85672429,
-        421186463
+        421186463,
+        85672429
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -71,8 +77,8 @@
         }
     ],
     "wof:id":1309695161,
-    "wof:lastmodified":1566714941,
-    "wof:name":"Hizar Jift",
+    "wof:lastmodified":1660081740,
+    "wof:name":"Hizarjoot",
     "wof:parent_id":421186463,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-iq",


### PR DESCRIPTION
This PR updates a locality name, adding names and swapping preferred/variant property values.
The name of this place is "Hizarjoot", other names have been stored as variants.

No PIP work needed, can merge once approved.