### PR TITLE
iq concordances, placetype local, and more

### DIFF
--- a/data/110/856/262/9/1108562629.geojson
+++ b/data/110/856/262/9/1108562629.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562629,
-    "wof:lastmodified":1694493024,
+    "wof:lastmodified":1695886537,
     "wof:name":"Tilkaif",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/110/856/263/1/1108562631.geojson
+++ b/data/110/856/263/1/1108562631.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562631,
-    "wof:lastmodified":1694493023,
+    "wof:lastmodified":1695886532,
     "wof:name":"Hamdaniya",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/110/856/263/3/1108562633.geojson
+++ b/data/110/856/263/3/1108562633.geojson
@@ -335,7 +335,7 @@
         }
     ],
     "wof:id":1108562633,
-    "wof:lastmodified":1694492413,
+    "wof:lastmodified":1695886118,
     "wof:name":"Mosul",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/110/856/263/5/1108562635.geojson
+++ b/data/110/856/263/5/1108562635.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562635,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Telafar",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/110/856/263/7/1108562637.geojson
+++ b/data/110/856/263/7/1108562637.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562637,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Sumel",
     "wof:parent_id":85672417,
     "wof:placetype":"county",

--- a/data/110/856/263/9/1108562639.geojson
+++ b/data/110/856/263/9/1108562639.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562639,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Ba'aj",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/110/856/264/1/1108562641.geojson
+++ b/data/110/856/264/1/1108562641.geojson
@@ -200,7 +200,7 @@
         }
     ],
     "wof:id":1108562641,
-    "wof:lastmodified":1694492413,
+    "wof:lastmodified":1695886118,
     "wof:name":"Hatra",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/110/856/264/5/1108562645.geojson
+++ b/data/110/856/264/5/1108562645.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562645,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Shirqat",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/110/856/264/7/1108562647.geojson
+++ b/data/110/856/264/7/1108562647.geojson
@@ -174,7 +174,7 @@
         }
     ],
     "wof:id":1108562647,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Baiji",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/110/856/264/9/1108562649.geojson
+++ b/data/110/856/264/9/1108562649.geojson
@@ -141,7 +141,7 @@
         }
     ],
     "wof:id":1108562649,
-    "wof:lastmodified":1694492413,
+    "wof:lastmodified":1695886118,
     "wof:name":"Haditha",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/110/856/265/1/1108562651.geojson
+++ b/data/110/856/265/1/1108562651.geojson
@@ -143,7 +143,7 @@
         }
     ],
     "wof:id":1108562651,
-    "wof:lastmodified":1694492413,
+    "wof:lastmodified":1695886117,
     "wof:name":"Khanaqin",
     "wof:parent_id":85672481,
     "wof:placetype":"county",

--- a/data/110/856/265/3/1108562653.geojson
+++ b/data/110/856/265/3/1108562653.geojson
@@ -89,7 +89,7 @@
         }
     ],
     "wof:id":1108562653,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886688,
     "wof:name":"Kifri",
     "wof:parent_id":85672481,
     "wof:placetype":"county",

--- a/data/110/856/265/5/1108562655.geojson
+++ b/data/110/856/265/5/1108562655.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562655,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Baladrooz",
     "wof:parent_id":85672481,
     "wof:placetype":"county",

--- a/data/110/856/265/7/1108562657.geojson
+++ b/data/110/856/265/7/1108562657.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562657,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Tooz",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/110/856/265/9/1108562659.geojson
+++ b/data/110/856/265/9/1108562659.geojson
@@ -74,7 +74,7 @@
         }
     ],
     "wof:id":1108562659,
-    "wof:lastmodified":1694493020,
+    "wof:lastmodified":1695886511,
     "wof:name":"Kalar",
     "wof:parent_id":85672475,
     "wof:placetype":"county",

--- a/data/110/856/266/3/1108562663.geojson
+++ b/data/110/856/266/3/1108562663.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562663,
-    "wof:lastmodified":1694493018,
+    "wof:lastmodified":1695886500,
     "wof:name":"Ba'quba",
     "wof:parent_id":85672481,
     "wof:placetype":"county",

--- a/data/110/856/266/5/1108562665.geojson
+++ b/data/110/856/266/5/1108562665.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108562665,
-    "wof:lastmodified":1694493019,
+    "wof:lastmodified":1695886504,
     "wof:name":"Tarmia",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/110/856/266/7/1108562667.geojson
+++ b/data/110/856/266/7/1108562667.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562667,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Rutba",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/110/856/266/9/1108562669.geojson
+++ b/data/110/856/266/9/1108562669.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562669,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Ka'im",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/110/856/267/1/1108562671.geojson
+++ b/data/110/856/267/1/1108562671.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562671,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Ain Al-Tamur",
     "wof:parent_id":85672443,
     "wof:placetype":"county",

--- a/data/110/856/267/3/1108562673.geojson
+++ b/data/110/856/267/3/1108562673.geojson
@@ -96,7 +96,7 @@
         }
     ],
     "wof:id":1108562673,
-    "wof:lastmodified":1694492412,
+    "wof:lastmodified":1695886117,
     "wof:name":"Badra",
     "wof:parent_id":85672473,
     "wof:placetype":"county",

--- a/data/110/856/267/5/1108562675.geojson
+++ b/data/110/856/267/5/1108562675.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562675,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Na'maniya",
     "wof:parent_id":85672473,
     "wof:placetype":"county",

--- a/data/110/856/267/7/1108562677.geojson
+++ b/data/110/856/267/7/1108562677.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562677,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Ali Al-Gharbi",
     "wof:parent_id":85672469,
     "wof:placetype":"county",

--- a/data/110/856/268/1/1108562681.geojson
+++ b/data/110/856/268/1/1108562681.geojson
@@ -123,7 +123,7 @@
         }
     ],
     "wof:id":1108562681,
-    "wof:lastmodified":1694492412,
+    "wof:lastmodified":1695886117,
     "wof:name":"Amara",
     "wof:parent_id":85672469,
     "wof:placetype":"county",

--- a/data/110/856/268/3/1108562683.geojson
+++ b/data/110/856/268/3/1108562683.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562683,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Rifa'i",
     "wof:parent_id":85672463,
     "wof:placetype":"county",

--- a/data/110/856/268/5/1108562685.geojson
+++ b/data/110/856/268/5/1108562685.geojson
@@ -87,7 +87,7 @@
         }
     ],
     "wof:id":1108562685,
-    "wof:lastmodified":1694492919,
+    "wof:lastmodified":1695886620,
     "wof:name":"Hai",
     "wof:parent_id":85672473,
     "wof:placetype":"county",

--- a/data/110/856/268/7/1108562687.geojson
+++ b/data/110/856/268/7/1108562687.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562687,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Afaq",
     "wof:parent_id":85672459,
     "wof:placetype":"county",

--- a/data/110/856/268/9/1108562689.geojson
+++ b/data/110/856/268/9/1108562689.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562689,
-    "wof:lastmodified":1694493021,
+    "wof:lastmodified":1695886522,
     "wof:name":"Hashimiya",
     "wof:parent_id":85672491,
     "wof:placetype":"county",

--- a/data/110/856/269/1/1108562691.geojson
+++ b/data/110/856/269/1/1108562691.geojson
@@ -228,7 +228,7 @@
         }
     ],
     "wof:id":1108562691,
-    "wof:lastmodified":1694492412,
+    "wof:lastmodified":1695886117,
     "wof:name":"Kufa",
     "wof:parent_id":85672439,
     "wof:placetype":"county",

--- a/data/110/856/269/3/1108562693.geojson
+++ b/data/110/856/269/3/1108562693.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562693,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Manathera",
     "wof:parent_id":85672439,
     "wof:placetype":"county",

--- a/data/110/856/269/5/1108562695.geojson
+++ b/data/110/856/269/5/1108562695.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562695,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886688,
     "wof:name":"Hilla",
     "wof:parent_id":85672491,
     "wof:placetype":"county",

--- a/data/110/856/269/9/1108562699.geojson
+++ b/data/110/856/269/9/1108562699.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108562699,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Shamiya",
     "wof:parent_id":85672459,
     "wof:placetype":"county",

--- a/data/110/856/270/1/1108562701.geojson
+++ b/data/110/856/270/1/1108562701.geojson
@@ -129,7 +129,7 @@
         }
     ],
     "wof:id":1108562701,
-    "wof:lastmodified":1694492412,
+    "wof:lastmodified":1695886117,
     "wof:name":"Hamza",
     "wof:parent_id":85672459,
     "wof:placetype":"county",

--- a/data/110/856/270/3/1108562703.geojson
+++ b/data/110/856/270/3/1108562703.geojson
@@ -99,7 +99,7 @@
         }
     ],
     "wof:id":1108562703,
-    "wof:lastmodified":1694492413,
+    "wof:lastmodified":1695886117,
     "wof:name":"Salman",
     "wof:parent_id":85672455,
     "wof:placetype":"county",

--- a/data/110/856/270/5/1108562705.geojson
+++ b/data/110/856/270/5/1108562705.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562705,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Rumaitha",
     "wof:parent_id":85672455,
     "wof:placetype":"county",

--- a/data/110/856/270/7/1108562707.geojson
+++ b/data/110/856/270/7/1108562707.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562707,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Mejar Al-Kabi",
     "wof:parent_id":85672469,
     "wof:placetype":"county",

--- a/data/110/856/270/9/1108562709.geojson
+++ b/data/110/856/270/9/1108562709.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562709,
-    "wof:lastmodified":1694493024,
+    "wof:lastmodified":1695886534,
     "wof:name":"Maimouna",
     "wof:parent_id":85672469,
     "wof:placetype":"county",

--- a/data/110/856/271/1/1108562711.geojson
+++ b/data/110/856/271/1/1108562711.geojson
@@ -147,7 +147,7 @@
         }
     ],
     "wof:id":1108562711,
-    "wof:lastmodified":1694492413,
+    "wof:lastmodified":1695886118,
     "wof:name":"Kahla",
     "wof:parent_id":85672469,
     "wof:placetype":"county",

--- a/data/110/856/271/3/1108562713.geojson
+++ b/data/110/856/271/3/1108562713.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108562713,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Qal'at Saleh",
     "wof:parent_id":85672469,
     "wof:placetype":"county",

--- a/data/110/856/271/7/1108562717.geojson
+++ b/data/110/856/271/7/1108562717.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562717,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Midaina",
     "wof:parent_id":85672453,
     "wof:placetype":"county",

--- a/data/110/856/271/9/1108562719.geojson
+++ b/data/110/856/271/9/1108562719.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562719,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Qurna",
     "wof:parent_id":85672453,
     "wof:placetype":"county",

--- a/data/110/856/272/1/1108562721.geojson
+++ b/data/110/856/272/1/1108562721.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562721,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886686,
     "wof:name":"Khidhir",
     "wof:parent_id":85672455,
     "wof:placetype":"county",

--- a/data/110/856/272/3/1108562723.geojson
+++ b/data/110/856/272/3/1108562723.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562723,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886690,
     "wof:name":"Suq Al-Shoyokh",
     "wof:parent_id":85672463,
     "wof:placetype":"county",

--- a/data/110/856/272/5/1108562725.geojson
+++ b/data/110/856/272/5/1108562725.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562725,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Chibayish",
     "wof:parent_id":85672463,
     "wof:placetype":"county",

--- a/data/110/856/272/7/1108562727.geojson
+++ b/data/110/856/272/7/1108562727.geojson
@@ -81,7 +81,7 @@
         }
     ],
     "wof:id":1108562727,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Zubair",
     "wof:parent_id":85672453,
     "wof:placetype":"county",

--- a/data/110/856/272/9/1108562729.geojson
+++ b/data/110/856/272/9/1108562729.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562729,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Shatt Al-Arab",
     "wof:parent_id":85672453,
     "wof:placetype":"county",

--- a/data/110/856/273/1/1108562731.geojson
+++ b/data/110/856/273/1/1108562731.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108562731,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Basrah",
     "wof:parent_id":85672453,
     "wof:placetype":"county",

--- a/data/110/856/273/5/1108562735.geojson
+++ b/data/110/856/273/5/1108562735.geojson
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":1108562735,
-    "wof:lastmodified":1694493020,
+    "wof:lastmodified":1695886518,
     "wof:name":"Abu Al-Khaseeb",
     "wof:parent_id":85672453,
     "wof:placetype":"county",

--- a/data/110/856/273/7/1108562737.geojson
+++ b/data/110/856/273/7/1108562737.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562737,
-    "wof:lastmodified":1694493020,
+    "wof:lastmodified":1695886518,
     "wof:name":"Fao",
     "wof:parent_id":85672453,
     "wof:placetype":"county",

--- a/data/110/856/273/9/1108562739.geojson
+++ b/data/110/856/273/9/1108562739.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562739,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886688,
     "wof:name":"Mada'in",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/110/856/274/1/1108562741.geojson
+++ b/data/110/856/274/1/1108562741.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108562741,
-    "wof:lastmodified":1694493022,
+    "wof:lastmodified":1695886524,
     "wof:name":"Shatra",
     "wof:parent_id":85672463,
     "wof:placetype":"county",

--- a/data/110/856/274/3/1108562743.geojson
+++ b/data/110/856/274/3/1108562743.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562743,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886688,
     "wof:name":"Hawiga",
     "wof:parent_id":1108804831,
     "wof:placetype":"county",

--- a/data/110/856/274/5/1108562745.geojson
+++ b/data/110/856/274/5/1108562745.geojson
@@ -104,7 +104,7 @@
         }
     ],
     "wof:id":1108562745,
-    "wof:lastmodified":1694492412,
+    "wof:lastmodified":1695886116,
     "wof:name":"Chamchamal",
     "wof:parent_id":85672475,
     "wof:placetype":"county",

--- a/data/110/856/274/7/1108562747.geojson
+++ b/data/110/856/274/7/1108562747.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108562747,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Mergasur",
     "wof:parent_id":85672425,
     "wof:placetype":"county",

--- a/data/110/856/274/9/1108562749.geojson
+++ b/data/110/856/274/9/1108562749.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108562749,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Choman",
     "wof:parent_id":85672425,
     "wof:placetype":"county",

--- a/data/110/856/275/3/1108562753.geojson
+++ b/data/110/856/275/3/1108562753.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108562753,
-    "wof:lastmodified":1694493017,
+    "wof:lastmodified":1695886494,
     "wof:name":"Pshdar",
     "wof:parent_id":85672475,
     "wof:placetype":"county",

--- a/data/110/856/275/5/1108562755.geojson
+++ b/data/110/856/275/5/1108562755.geojson
@@ -89,7 +89,7 @@
         }
     ],
     "wof:id":1108562755,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Rania",
     "wof:parent_id":85672475,
     "wof:placetype":"county",

--- a/data/110/856/275/7/1108562757.geojson
+++ b/data/110/856/275/7/1108562757.geojson
@@ -95,7 +95,7 @@
         }
     ],
     "wof:id":1108562757,
-    "wof:lastmodified":1694492412,
+    "wof:lastmodified":1695886117,
     "wof:name":"Shaqlawa",
     "wof:parent_id":85672425,
     "wof:placetype":"county",

--- a/data/110/856/275/9/1108562759.geojson
+++ b/data/110/856/275/9/1108562759.geojson
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108562759,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Dokan",
     "wof:parent_id":85672475,
     "wof:placetype":"county",

--- a/data/110/856/276/1/1108562761.geojson
+++ b/data/110/856/276/1/1108562761.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108562761,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Sulaymaniya",
     "wof:parent_id":85672475,
     "wof:placetype":"county",

--- a/data/110/856/276/3/1108562763.geojson
+++ b/data/110/856/276/3/1108562763.geojson
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":1108562763,
-    "wof:lastmodified":1694493018,
+    "wof:lastmodified":1695886500,
     "wof:name":"Sharbazher",
     "wof:parent_id":85672475,
     "wof:placetype":"county",

--- a/data/110/856/276/5/1108562765.geojson
+++ b/data/110/856/276/5/1108562765.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108562765,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Penjwin",
     "wof:parent_id":85672475,
     "wof:placetype":"county",

--- a/data/110/856/276/7/1108562767.geojson
+++ b/data/110/856/276/7/1108562767.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108562767,
-    "wof:lastmodified":1694493024,
+    "wof:lastmodified":1695886538,
     "wof:name":"Darbandihkan",
     "wof:parent_id":1108804835,
     "wof:placetype":"county",

--- a/data/110/856/277/1/1108562771.geojson
+++ b/data/110/856/277/1/1108562771.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108562771,
-    "wof:lastmodified":1694493020,
+    "wof:lastmodified":1695886511,
     "wof:name":"Adhamia",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/110/856/277/3/1108562773.geojson
+++ b/data/110/856/277/3/1108562773.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1108562773,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Daur",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/110/856/277/5/1108562775.geojson
+++ b/data/110/856/277/5/1108562775.geojson
@@ -92,7 +92,7 @@
         }
     ],
     "wof:id":1108562775,
-    "wof:lastmodified":1694493021,
+    "wof:lastmodified":1695886520,
     "wof:name":"Daquq",
     "wof:parent_id":1108804831,
     "wof:placetype":"county",

--- a/data/110/856/277/7/1108562777.geojson
+++ b/data/110/856/277/7/1108562777.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562777,
-    "wof:lastmodified":1694493021,
+    "wof:lastmodified":1695886521,
     "wof:name":"Hindiya",
     "wof:parent_id":85672443,
     "wof:placetype":"county",

--- a/data/110/856/277/9/1108562779.geojson
+++ b/data/110/856/277/9/1108562779.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108562779,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Makhmur",
     "wof:parent_id":85672425,
     "wof:placetype":"county",

--- a/data/110/856/278/1/1108562781.geojson
+++ b/data/110/856/278/1/1108562781.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562781,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Azezia",
     "wof:parent_id":85672473,
     "wof:placetype":"county",

--- a/data/110/856/278/3/1108562783.geojson
+++ b/data/110/856/278/3/1108562783.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562783,
-    "wof:lastmodified":1694492678,
+    "wof:lastmodified":1695886690,
     "wof:name":"Suwaira",
     "wof:parent_id":85672473,
     "wof:placetype":"county",

--- a/data/110/856/278/5/1108562785.geojson
+++ b/data/110/856/278/5/1108562785.geojson
@@ -102,7 +102,7 @@
         }
     ],
     "wof:id":1108562785,
-    "wof:lastmodified":1694492413,
+    "wof:lastmodified":1695886117,
     "wof:name":"Resafa",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/110/856/278/9/1108562789.geojson
+++ b/data/110/856/278/9/1108562789.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562789,
-    "wof:lastmodified":1694492678,
+    "wof:lastmodified":1695886690,
     "wof:name":"Thawra1",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/110/856/279/1/1108562791.geojson
+++ b/data/110/856/279/1/1108562791.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562791,
-    "wof:lastmodified":1694492678,
+    "wof:lastmodified":1695886690,
     "wof:name":"Thawra2",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/110/856/279/3/1108562793.geojson
+++ b/data/110/856/279/3/1108562793.geojson
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":1108562793,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Karkh",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/110/856/279/5/1108562795.geojson
+++ b/data/110/856/279/5/1108562795.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562795,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Kadhimia",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/110/856/279/7/1108562797.geojson
+++ b/data/110/856/279/7/1108562797.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562797,
-    "wof:lastmodified":1694492678,
+    "wof:lastmodified":1695886690,
     "wof:name":"Thethar",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/110/856/279/9/1108562799.geojson
+++ b/data/110/856/279/9/1108562799.geojson
@@ -236,7 +236,7 @@
         }
     ],
     "wof:id":1108562799,
-    "wof:lastmodified":1694492413,
+    "wof:lastmodified":1695886117,
     "wof:name":"Samarra",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/110/856/280/1/1108562801.geojson
+++ b/data/110/856/280/1/1108562801.geojson
@@ -111,7 +111,7 @@
         }
     ],
     "wof:id":1108562801,
-    "wof:lastmodified":1694492412,
+    "wof:lastmodified":1695886116,
     "wof:name":"Ana",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/110/856/280/3/1108562803.geojson
+++ b/data/110/856/280/3/1108562803.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562803,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Ru'ua",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/110/856/280/7/1108562807.geojson
+++ b/data/110/856/280/7/1108562807.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562807,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Dabes",
     "wof:parent_id":1108804831,
     "wof:placetype":"county",

--- a/data/110/856/280/9/1108562809.geojson
+++ b/data/110/856/280/9/1108562809.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108562809,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Fares",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/110/880/483/1/1108804831.geojson
+++ b/data/110/880/483/1/1108804831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.96523,
-    "geom:area_square_m":9738150952.653294,
+    "geom:area_square_m":9738150952.653572,
     "geom:bbox":"43.262948,34.685507,44.860252,35.908843",
     "geom:latitude":35.321311,
     "geom:longitude":44.157405,
@@ -270,11 +270,13 @@
         "digitalenvoy:region_code":25631,
         "fips:code":"IZ13",
         "hasc:id":"IQ.TS",
+        "iso:code":"IQ-KI",
         "iso:id":"IQ-KI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:created":1485375230,
-    "wof:geomhash":"a2475fb31c3f260509b621c8bad183a5",
+    "wof:geomhash":"99fc1ad33aee489a7fcc2fddfb9de4c1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -290,7 +292,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1587587511,
+    "wof:lastmodified":1695884439,
     "wof:name":"Kirkuk",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/110/880/483/5/1108804835.geojson
+++ b/data/110/880/483/5/1108804835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.213857,
-    "geom:area_square_m":2160376168.66958,
+    "geom:area_square_m":2160376168.669937,
     "geom:bbox":"45.54006958,34.894011,46.198975624,35.49328",
     "geom:latitude":35.217409,
     "geom:longitude":45.865321,
@@ -243,11 +243,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "fips:code":"IZ05",
-        "hasc:id":"IQ.HA"
+        "hasc:id":"IQ.HA",
+        "iso:code_pseudo":"IQ-HA"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"IQ",
     "wof:created":1485375240,
-    "wof:geomhash":"e0a786dc2ed82c7fa98b2eb7e7a59bbe",
+    "wof:geomhash":"ebd551bdd6c758378f02065c0c8ad3e4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -263,7 +265,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1566714715,
+    "wof:lastmodified":1695884329,
     "wof:name":"Halabja",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/421/169/765/421169765.geojson
+++ b/data/421/169/765/421169765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12789,
-    "geom:area_square_m":1310325415.184835,
+    "geom:area_square_m":1310326118.052887,
     "geom:bbox":"44.286455,33.749773,44.789616,34.292958",
     "geom:latitude":34.045239,
     "geom:longitude":44.531915,
@@ -124,7 +124,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cee8c09824ed73c9e74d2a40d340c5c1",
+    "wof:geomhash":"3b84362dc75bc9de67eed1bf25f193ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":421169765,
-    "wof:lastmodified":1690934375,
+    "wof:lastmodified":1695886421,
     "wof:name":"Khalis",
     "wof:parent_id":85672481,
     "wof:placetype":"county",

--- a/data/421/172/357/421172357.geojson
+++ b/data/421/172/357/421172357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.388444,
-    "geom:area_square_m":4113573921.731835,
+    "geom:area_square_m":4113573334.99895,
     "geom:bbox":"45.698242,30.782571,46.945091,31.406977",
     "geom:latitude":31.082258,
     "geom:longitude":46.227656,
@@ -317,7 +317,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"969935264671d9fdf1729b87faa3ce92",
+    "wof:geomhash":"f056a05fcc1f22f434326db779b0f09d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -327,7 +327,7 @@
         }
     ],
     "wof:id":421172357,
-    "wof:lastmodified":1690934378,
+    "wof:lastmodified":1695886421,
     "wof:name":"Nassriya",
     "wof:parent_id":85672463,
     "wof:placetype":"county",

--- a/data/421/172/365/421172365.geojson
+++ b/data/421/172/365/421172365.geojson
@@ -97,7 +97,7 @@
         }
     ],
     "wof:id":421172365,
-    "wof:lastmodified":1694493017,
+    "wof:lastmodified":1695886494,
     "wof:name":"Shikhan",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/421/172/849/421172849.geojson
+++ b/data/421/172/849/421172849.geojson
@@ -97,7 +97,7 @@
         }
     ],
     "wof:id":421172849,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Musayab",
     "wof:parent_id":85672491,
     "wof:placetype":"county",

--- a/data/421/177/881/421177881.geojson
+++ b/data/421/177/881/421177881.geojson
@@ -101,7 +101,7 @@
         }
     ],
     "wof:id":421177881,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Heet",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/421/178/933/421178933.geojson
+++ b/data/421/178/933/421178933.geojson
@@ -226,7 +226,7 @@
         }
     ],
     "wof:id":421178933,
-    "wof:lastmodified":1694492485,
+    "wof:lastmodified":1695886422,
     "wof:name":"Ramadi",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/421/180/939/421180939.geojson
+++ b/data/421/180/939/421180939.geojson
@@ -124,7 +124,7 @@
         }
     ],
     "wof:id":421180939,
-    "wof:lastmodified":1694492484,
+    "wof:lastmodified":1695886422,
     "wof:name":"Balad",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/421/181/959/421181959.geojson
+++ b/data/421/181/959/421181959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.22917,
-    "geom:area_square_m":2401308100.632632,
+    "geom:area_square_m":2401306985.913373,
     "geom:bbox":"44.5426,31.738474,45.287858,32.408767",
     "geom:latitude":32.069744,
     "geom:longitude":44.926411,
@@ -92,7 +92,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dfacd7e6792a2737abbf408f0edcf90f",
+    "wof:geomhash":"159b334456edd17b59221fbe176c2553",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +102,7 @@
         }
     ],
     "wof:id":421181959,
-    "wof:lastmodified":1627522209,
+    "wof:lastmodified":1695886687,
     "wof:name":"Diwaniya",
     "wof:parent_id":85672459,
     "wof:placetype":"county",

--- a/data/421/182/249/421182249.geojson
+++ b/data/421/182/249/421182249.geojson
@@ -106,7 +106,7 @@
         }
     ],
     "wof:id":421182249,
-    "wof:lastmodified":1694493021,
+    "wof:lastmodified":1695886520,
     "wof:name":"Amedi",
     "wof:parent_id":85672417,
     "wof:placetype":"county",

--- a/data/421/183/885/421183885.geojson
+++ b/data/421/183/885/421183885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.152817,
-    "geom:area_square_m":1543758947.599097,
+    "geom:area_square_m":1543759325.867128,
     "geom:bbox":"45.671247,34.894011,46.198976,35.49328",
     "geom:latitude":35.217062,
     "geom:longitude":45.934839,
@@ -269,7 +269,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2f765a4146d58f3692770264971060b9",
+    "wof:geomhash":"cca181c9f38ae7702a3643062d0af749",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -279,7 +279,7 @@
         }
     ],
     "wof:id":421183885,
-    "wof:lastmodified":1690934384,
+    "wof:lastmodified":1695886422,
     "wof:name":"Halabja",
     "wof:parent_id":1108804835,
     "wof:placetype":"county",

--- a/data/421/184/253/421184253.geojson
+++ b/data/421/184/253/421184253.geojson
@@ -97,7 +97,7 @@
         }
     ],
     "wof:id":421184253,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Muqdadiya",
     "wof:parent_id":85672481,
     "wof:placetype":"county",

--- a/data/421/184/255/421184255.geojson
+++ b/data/421/184/255/421184255.geojson
@@ -279,7 +279,7 @@
         }
     ],
     "wof:id":421184255,
-    "wof:lastmodified":1694492485,
+    "wof:lastmodified":1695886422,
     "wof:name":"Najaf",
     "wof:parent_id":85672439,
     "wof:placetype":"county",

--- a/data/421/184/257/421184257.geojson
+++ b/data/421/184/257/421184257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05321,
-    "geom:area_square_m":549902873.63067,
+    "geom:area_square_m":549902991.005854,
     "geom:bbox":"43.845425,33.15085,44.205286,33.430307",
     "geom:latitude":33.302555,
     "geom:longitude":44.027077,
@@ -196,7 +196,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"255f452c3a6163dcd271324542645063",
+    "wof:geomhash":"1ff54e3faad6901bab64201f3eb4e55c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +206,7 @@
         }
     ],
     "wof:id":421184257,
-    "wof:lastmodified":1690934383,
+    "wof:lastmodified":1695886422,
     "wof:name":"Abu Ghraib",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/421/186/243/421186243.geojson
+++ b/data/421/186/243/421186243.geojson
@@ -288,7 +288,7 @@
         }
     ],
     "wof:id":421186243,
-    "wof:lastmodified":1694492484,
+    "wof:lastmodified":1695886422,
     "wof:name":"Tikrit",
     "wof:parent_id":85672435,
     "wof:placetype":"county",

--- a/data/421/186/449/421186449.geojson
+++ b/data/421/186/449/421186449.geojson
@@ -195,7 +195,7 @@
         }
     ],
     "wof:id":421186449,
-    "wof:lastmodified":1694492484,
+    "wof:lastmodified":1695886422,
     "wof:name":"Sinjar",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/421/186/459/421186459.geojson
+++ b/data/421/186/459/421186459.geojson
@@ -205,7 +205,7 @@
         }
     ],
     "wof:id":421186459,
-    "wof:lastmodified":1694492484,
+    "wof:lastmodified":1695886422,
     "wof:name":"Kut",
     "wof:parent_id":85672473,
     "wof:placetype":"county",

--- a/data/421/186/463/421186463.geojson
+++ b/data/421/186/463/421186463.geojson
@@ -96,7 +96,7 @@
         }
     ],
     "wof:id":421186463,
-    "wof:lastmodified":1694493024,
+    "wof:lastmodified":1695886533,
     "wof:name":"Akre",
     "wof:parent_id":85672429,
     "wof:placetype":"county",

--- a/data/421/188/909/421188909.geojson
+++ b/data/421/188/909/421188909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.229755,
-    "geom:area_square_m":2392016776.359649,
+    "geom:area_square_m":2392017165.719277,
     "geom:bbox":"44.1779,32.411827,45.177948,32.983957",
     "geom:latitude":32.650738,
     "geom:longitude":44.650907,
@@ -109,7 +109,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5c73a2a36b65d8b08b940942c38a0fa2",
+    "wof:geomhash":"214389dfe4bf363413e78b025d7319a6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +119,7 @@
         }
     ],
     "wof:id":421188909,
-    "wof:lastmodified":1642551832,
+    "wof:lastmodified":1695886539,
     "wof:name":"Mahawil",
     "wof:parent_id":85672491,
     "wof:placetype":"county",

--- a/data/421/189/307/421189307.geojson
+++ b/data/421/189/307/421189307.geojson
@@ -101,7 +101,7 @@
         }
     ],
     "wof:id":421189307,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886688,
     "wof:name":"Mahmoudiya",
     "wof:parent_id":85672447,
     "wof:placetype":"county",

--- a/data/421/191/407/421191407.geojson
+++ b/data/421/191/407/421191407.geojson
@@ -97,7 +97,7 @@
         }
     ],
     "wof:id":421191407,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Falluja",
     "wof:parent_id":85672483,
     "wof:placetype":"county",

--- a/data/421/194/967/421194967.geojson
+++ b/data/421/194/967/421194967.geojson
@@ -97,7 +97,7 @@
         }
     ],
     "wof:id":421194967,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Kerbala",
     "wof:parent_id":85672443,
     "wof:placetype":"county",

--- a/data/421/199/293/421199293.geojson
+++ b/data/421/199/293/421199293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.28036,
-    "geom:area_square_m":2824529866.324753,
+    "geom:area_square_m":2824529985.029578,
     "geom:bbox":"43.845999,34.882961,44.779904,35.908843",
     "geom:latitude":35.43573,
     "geom:longitude":44.300972,
@@ -354,7 +354,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ebcf02ce52fe8afcfd0e46fc64dfd025",
+    "wof:geomhash":"45558df39fbedf4be75b66b1fc79fa27",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -364,7 +364,7 @@
         }
     ],
     "wof:id":421199293,
-    "wof:lastmodified":1690934381,
+    "wof:lastmodified":1695886422,
     "wof:name":"Kirkuk",
     "wof:parent_id":1108804831,
     "wof:placetype":"county",

--- a/data/421/200/817/421200817.geojson
+++ b/data/421/200/817/421200817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.289846,
-    "geom:area_square_m":2895549021.443299,
+    "geom:area_square_m":2895549085.306772,
     "geom:bbox":"43.590233,35.730368,44.31246,36.430186",
     "geom:latitude":36.10751,
     "geom:longitude":44.006512,
@@ -407,7 +407,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d19fa1e57ab3c7080e259e8c0c90eec3",
+    "wof:geomhash":"ef198a38aa21af9192abf436f890b7a8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -417,7 +417,7 @@
         }
     ],
     "wof:id":421200817,
-    "wof:lastmodified":1690934382,
+    "wof:lastmodified":1695886422,
     "wof:name":"Erbil",
     "wof:parent_id":85672425,
     "wof:placetype":"county",

--- a/data/421/204/025/421204025.geojson
+++ b/data/421/204/025/421204025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100009,
-    "geom:area_square_m":988144096.792999,
+    "geom:area_square_m":988144030.366863,
     "geom:bbox":"42.808514,36.786587,43.302459,37.119331",
     "geom:latitude":36.959606,
     "geom:longitude":43.05416,
@@ -117,7 +117,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"825fa830187f6ca06378334968a194b2",
+    "wof:geomhash":"a1c76247c6fd0f30ff30dd179261071d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +127,7 @@
         }
     ],
     "wof:id":421204025,
-    "wof:lastmodified":1642551773,
+    "wof:lastmodified":1695886516,
     "wof:name":"Dahuk",
     "wof:parent_id":85672417,
     "wof:placetype":"county",

--- a/data/421/205/333/421205333.geojson
+++ b/data/421/205/333/421205333.geojson
@@ -261,7 +261,7 @@
         }
     ],
     "wof:id":421205333,
-    "wof:lastmodified":1694492485,
+    "wof:lastmodified":1695886422,
     "wof:name":"Samawa",
     "wof:parent_id":85672455,
     "wof:placetype":"county",

--- a/data/856/321/91/85632191.geojson
+++ b/data/856/321/91/85632191.geojson
@@ -1266,6 +1266,7 @@
         "hasc:id":"IQ",
         "icao:code":"YI",
         "ioc:id":"IRQ",
+        "iso:code":"IQ",
         "itu:id":"IRQ",
         "loc:id":"n79077342",
         "m49:code":"368",
@@ -1280,6 +1281,7 @@
         "wk:page":"Iraq",
         "wmo:id":"IQ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:country_alpha3":"IRQ",
     "wof:geom_alt":[
@@ -1304,7 +1306,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1694639498,
+    "wof:lastmodified":1695881152,
     "wof:name":"Iraq",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/724/17/85672417.geojson
+++ b/data/856/724/17/85672417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.666612,
-    "geom:area_square_m":6577537610.495365,
+    "geom:area_square_m":6577537872.611279,
     "geom:bbox":"42.349622,36.705001,44.100865,37.381556",
     "geom:latitude":37.062579,
     "geom:longitude":43.13874,
@@ -343,17 +343,19 @@
         "gn:id":97270,
         "gp:id":2345840,
         "hasc:id":"IQ.DA",
+        "iso:code":"IQ-DA",
         "iso:id":"IQ-DA",
         "qs_pg:id":427265,
         "unlc:id":"IQ-DA",
         "wd:id":"Q189541",
         "wk:page":"Dohuk Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c49bb3075d2cb72985354e6f3962135d",
+    "wof:geomhash":"e2fe023e4f61cc12c06d9bf60387ae8a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -369,7 +371,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934362,
+    "wof:lastmodified":1695884605,
     "wof:name":"Dihok",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/724/25/85672425.geojson
+++ b/data/856/724/25/85672425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.55668,
-    "geom:area_square_m":15510654752.612425,
+    "geom:area_square_m":15510654808.47846,
     "geom:bbox":"43.315136,35.420327,45.071915,37.323001",
     "geom:latitude":36.309493,
     "geom:longitude":44.189861,
@@ -342,17 +342,19 @@
         "gn:id":95445,
         "gp:id":2345843,
         "hasc:id":"IQ.AR",
+        "iso:code":"IQ-AR",
         "iso:id":"IQ-AR",
         "qs_pg:id":423779,
         "unlc:id":"IQ-AR",
         "wd:id":"Q213189",
         "wk:page":"Erbil Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"548c1d301351cacd70a9f8d3afcbe08e",
+    "wof:geomhash":"69f50098363106bb76a4781ca4550688",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -368,7 +370,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934366,
+    "wof:lastmodified":1695884564,
     "wof:name":"Arbil",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/724/29/85672429.geojson
+++ b/data/856/724/29/85672429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.748977,
-    "geom:area_square_m":37490872575.839493,
+    "geom:area_square_m":37490874483.599831,
     "geom:bbox":"41.211229,34.945451,44.303797,37.065281",
     "geom:latitude":36.023199,
     "geom:longitude":42.482811,
@@ -346,16 +346,18 @@
         "gn:id":92877,
         "gp:id":2345847,
         "hasc:id":"IQ.NI",
+        "iso:code":"IQ-NI",
         "iso:id":"IQ-NI",
         "qs_pg:id":211641,
         "wd:id":"Q189352",
         "wk:page":"Nineveh Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee2defc8dde438636997645fe31fc57d",
+    "wof:geomhash":"b007dfcd9c34cd55ce531884e3089635",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -371,7 +373,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934361,
+    "wof:lastmodified":1695884565,
     "wof:name":"Ninawa",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/35/85672435.geojson
+++ b/data/856/724/35/85672435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.440937,
-    "geom:area_square_m":24856982528.379848,
+    "geom:area_square_m":24856982528.380371,
     "geom:bbox":"42.499911,33.621726,44.956597,35.724284",
     "geom:latitude":34.555683,
     "geom:longitude":43.622417,
@@ -154,15 +154,17 @@
         "gn:id":91695,
         "gp:id":2345850,
         "hasc:id":"IQ.SD",
+        "iso:code":"IQ-SD",
         "iso:id":"IQ-SD",
         "qs_pg:id":900704,
         "unlc:id":"IQ-SD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"78eda7fb368724a729eacc838c5dedcf",
+    "wof:geomhash":"df7ea6f0a9db56f4dd21b7491730bfb9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +180,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1627522212,
+    "wof:lastmodified":1695884754,
     "wof:name":"Sala ad-Din",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/39/85672439.geojson
+++ b/data/856/724/39/85672439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.700786,
-    "geom:area_square_m":28585922460.33086,
+    "geom:area_square_m":28585922539.972862,
     "geom:bbox":"42.808366,29.84737,44.726933,32.330295",
     "geom:latitude":31.127798,
     "geom:longitude":43.816056,
@@ -334,17 +334,19 @@
         "gn:id":98862,
         "gp:id":2345849,
         "hasc:id":"IQ.NA",
+        "iso:code":"IQ-NA",
         "iso:id":"IQ-NA",
         "qs_pg:id":219565,
         "unlc:id":"IQ-NA",
         "wd:id":"Q192882",
         "wk:page":"Najaf Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c159d53ce1272d50ffa6cd573de0a635",
+    "wof:geomhash":"5ef0b25395dbee02755aee6f74c473af",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -360,7 +362,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934364,
+    "wof:lastmodified":1695884513,
     "wof:name":"An-Najaf",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/43/85672443.geojson
+++ b/data/856/724/43/85672443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.478707,
-    "geom:area_square_m":4991798221.986091,
+    "geom:area_square_m":4991798221.985952,
     "geom:bbox":"43.166414,32.168487,44.313239,32.838264",
     "geom:latitude":32.508408,
     "geom:longitude":43.819925,
@@ -325,17 +325,19 @@
         "gn:id":94823,
         "gp:id":2345844,
         "hasc:id":"IQ.KA",
+        "iso:code":"IQ-KA",
         "iso:id":"IQ-KA",
         "qs_pg:id":211642,
         "unlc:id":"IQ-KA",
         "wd:id":"Q214104",
         "wk:page":"Karbala Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"69574a3890219684e40d023a0dd54118",
+    "wof:geomhash":"0c9d2dfd5d23f9691405a09f7d37b374",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -351,7 +353,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934363,
+    "wof:lastmodified":1695884513,
     "wof:name":"Karbala'",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/47/85672447.geojson
+++ b/data/856/724/47/85672447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.501833,
-    "geom:area_square_m":5187731493.966923,
+    "geom:area_square_m":5187731493.96717,
     "geom:bbox":"43.845425,32.834484,44.969163,33.774751",
     "geom:latitude":33.27722,
     "geom:longitude":44.399384,
@@ -796,11 +796,13 @@
         "gn:id":98180,
         "gp:id":2345839,
         "hasc:id":"IQ.BG",
+        "iso:code":"IQ-BG",
         "iso:id":"IQ-BG",
         "qs_pg:id":1135097,
         "unlc:id":"IQ-BG",
         "wd:id":"Q1530"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421178393
     ],
@@ -808,7 +810,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57b275fd5f9b09c89006303cbedecdea",
+    "wof:geomhash":"00e14570d18a2c03de99ecbdc5afaa00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -824,7 +826,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934365,
+    "wof:lastmodified":1695884778,
     "wof:name":"Baghdad",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/53/85672453.geojson
+++ b/data/856/724/53/85672453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.643992,
-    "geom:area_square_m":17535043875.774906,
+    "geom:area_square_m":17535042337.616367,
     "geom:bbox":"46.557102,29.102965,48.627752,31.280385",
     "geom:latitude":30.388164,
     "geom:longitude":47.409334,
@@ -151,15 +151,17 @@
         "gn:id":89341,
         "gp:id":2345834,
         "hasc:id":"IQ.BA",
+        "iso:code":"IQ-BA",
         "iso:id":"IQ-BA",
         "qs_pg:id":1135096,
         "unlc:id":"IQ-BA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7f93d4047b0b34c8d58bdf5f8c0918b1",
+    "wof:geomhash":"81e56b481deb4e5d8a27f33b187d53a0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +177,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1627522207,
+    "wof:lastmodified":1695884754,
     "wof:name":"Al-Basrah",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/55/85672455.geojson
+++ b/data/856/724/55/85672455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.887426,
-    "geom:area_square_m":52233793540.633263,
+    "geom:area_square_m":52233794451.715141,
     "geom:bbox":"43.847381,29.061208,46.747211,31.729635",
     "geom:latitude":30.189786,
     "geom:longitude":45.382582,
@@ -286,16 +286,18 @@
         "gn:id":99032,
         "gp:id":2345835,
         "hasc:id":"IQ.MU",
+        "iso:code":"IQ-MU",
         "iso:id":"IQ-MU",
         "qs_pg:id":191367,
         "wd:id":"Q212761",
         "wk:page":"Muthanna Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e9d7d3e21de8390b12b622cf4954a5ed",
+    "wof:geomhash":"60e7b556b9c9918095a80fff49dafe22",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -311,7 +313,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934364,
+    "wof:lastmodified":1695884513,
     "wof:name":"Al-Muthannia",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/59/85672459.geojson
+++ b/data/856/724/59/85672459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.816278,
-    "geom:area_square_m":8571593681.969341,
+    "geom:area_square_m":8571593425.763546,
     "geom:bbox":"44.406078,31.259173,45.785806,32.408767",
     "geom:latitude":31.871769,
     "geom:longitude":45.065866,
@@ -314,17 +314,19 @@
         "gn:id":99022,
         "gp:id":2345836,
         "hasc:id":"IQ.QA",
+        "iso:code":"IQ-QA",
         "iso:id":"IQ-QA",
         "qs_pg:id":1311207,
         "unlc:id":"IQ-QA",
         "wd:id":"Q62987",
         "wk:page":"Al-Q\u0101disiyyah Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c11fda08f81eb43891121897305b2cfb",
+    "wof:geomhash":"9fe290e28dfbc4a149f1c06a597623db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -340,7 +342,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934361,
+    "wof:lastmodified":1695884513,
     "wof:name":"Al-Qadisiyah",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/63/85672463.geojson
+++ b/data/856/724/63/85672463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.290815,
-    "geom:area_square_m":13650990882.892399,
+    "geom:area_square_m":13650990821.141922,
     "geom:bbox":"45.698242,30.50013,47.1372,32.010103",
     "geom:latitude":31.209398,
     "geom:longitude":46.342335,
@@ -270,17 +270,19 @@
         "gn:id":97019,
         "gp:id":2345841,
         "hasc:id":"IQ.DQ",
+        "iso:code":"IQ-DQ",
         "iso:id":"IQ-DQ",
         "qs_pg:id":894894,
         "unlc:id":"IQ-DQ",
         "wd:id":"Q215649",
         "wk:page":"Dhi Qar Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"91fa669b373a81406a8bbdd232febca1",
+    "wof:geomhash":"7d724ed482fea8d539dab6760dd90df7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -296,7 +298,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934364,
+    "wof:lastmodified":1695884616,
     "wof:name":"Dhi-Qar",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/69/85672469.geojson
+++ b/data/856/724/69/85672469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.594721,
-    "geom:area_square_m":16740623030.291792,
+    "geom:area_square_m":16740622540.031473,
     "geom:bbox":"46.288708,31.129851,47.865817,32.8517",
     "geom:latitude":31.899643,
     "geom:longitude":47.054923,
@@ -326,17 +326,19 @@
         "gn:id":93540,
         "gp:id":2345846,
         "hasc:id":"IQ.MA",
+        "iso:code":"IQ-MA",
         "iso:id":"IQ-MA",
         "qs_pg:id":959517,
         "unlc:id":"IQ-MA",
         "wd:id":"Q213170",
         "wk:page":"Maysan Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be783379cf321bb539868c92af6fca51",
+    "wof:geomhash":"e901011456874f0dfc3ac8d237cdeb6d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -352,7 +354,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934361,
+    "wof:lastmodified":1695884616,
     "wof:name":"Maysan",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/73/85672473.geojson
+++ b/data/856/724/73/85672473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.708191,
-    "geom:area_square_m":17780392601.318684,
+    "geom:area_square_m":17780393965.196312,
     "geom:bbox":"44.530674,31.933702,46.610236,33.511912",
     "geom:latitude":32.668726,
     "geom:longitude":45.730262,
@@ -337,17 +337,19 @@
         "gn:id":89693,
         "gp:id":2345848,
         "hasc:id":"IQ.WA",
+        "iso:code":"IQ-WA",
         "iso:id":"IQ-WA",
         "qs_pg:id":959518,
         "unlc:id":"IQ-WA",
         "wd:id":"Q189747",
         "wk:page":"Wasit Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"91251a2b3e396447a34af50edfb9e9f9",
+    "wof:geomhash":"90ba12b9bb550edeacc6ddcedac9101f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -363,7 +365,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934362,
+    "wof:lastmodified":1695884513,
     "wof:name":"Wasit",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/75/85672475.geojson
+++ b/data/856/724/75/85672475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.522474,
-    "geom:area_square_m":15308776033.207146,
+    "geom:area_square_m":15308775440.363781,
     "geom:bbox":"44.522706,34.510812,46.347891,36.51979",
     "geom:latitude":35.589184,
     "geom:longitude":45.240842,
@@ -328,17 +328,19 @@
         "gn:id":98465,
         "gp:id":2345837,
         "hasc:id":"IQ.SL",
+        "iso:code":"IQ-SU",
         "iso:id":"IQ-SU",
         "qs_pg:id":891326,
         "unlc:id":"IQ-SU",
         "wd:id":"Q213182",
         "wk:page":"Sulaymaniyah Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"78315476a43b7eedbe83e1b2eabcb9c6",
+    "wof:geomhash":"45257f3e90beaa10daa207f5e858be51",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -354,7 +356,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934362,
+    "wof:lastmodified":1695884576,
     "wof:name":"As-Sulaymaniyah",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/724/81/85672481.geojson
+++ b/data/856/724/81/85672481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.813744,
-    "geom:area_square_m":18600743646.535187,
+    "geom:area_square_m":18600743646.324661,
     "geom:bbox":"44.286455,33.071397,45.96133,35.113439",
     "geom:latitude":33.962141,
     "geom:longitude":45.10362,
@@ -334,17 +334,19 @@
         "gn:id":96965,
         "gp:id":2345842,
         "hasc:id":"IQ.DI",
+        "iso:code":"IQ-DI",
         "iso:id":"IQ-DI",
         "nyt:id":"N66993953892767803791",
         "qs_pg:id":423778,
         "wd:id":"Q217075",
         "wk:page":"Diyala Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"776199be115d0773696fb3f94380f71f",
+    "wof:geomhash":"4616d4412be5d2d6b73412f7f2090861",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -360,7 +362,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934363,
+    "wof:lastmodified":1695884650,
     "wof:name":"Diyala",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/83/85672483.geojson
+++ b/data/856/724/83/85672483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":13.1609,
-    "geom:area_square_m":136505084777.931519,
+    "geom:area_square_m":136505084777.927032,
     "geom:bbox":"38.793603,30.599919,44.159586,35.158504",
     "geom:latitude":32.973771,
     "geom:longitude":41.615678,
@@ -306,16 +306,18 @@
         "gn:id":99592,
         "gp:id":2345833,
         "hasc:id":"IQ.AN",
+        "iso:code":"IQ-AN",
         "iso:id":"IQ-AN",
         "qs_pg:id":191366,
         "wd:id":"Q187334",
         "wk:page":"Al Anbar Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5568d1eeef66c6f452a9ac28a31f5e9c",
+    "wof:geomhash":"668229ff88cdd9f85f7d978950b6425f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -331,7 +333,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934365,
+    "wof:lastmodified":1695884513,
     "wof:name":"Al-Anbar",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/856/724/91/85672491.geojson
+++ b/data/856/724/91/85672491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.512922,
-    "geom:area_square_m":5347213081.274001,
+    "geom:area_square_m":5347213081.274798,
     "geom:bbox":"44.046361,32.097969,45.201462,33.126781",
     "geom:latitude":32.531324,
     "geom:longitude":44.598911,
@@ -335,17 +335,19 @@
         "gn:id":98227,
         "gp:id":2345838,
         "hasc:id":"IQ.BB",
+        "iso:code":"IQ-BB",
         "iso:id":"IQ-BB",
         "qs_pg:id":427264,
         "unlc:id":"IQ-BB",
         "wd:id":"Q59202",
         "wk:page":"Babil Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IQ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1cf8a18963c31edcca5c0598531cebf2",
+    "wof:geomhash":"fe98a8da3039668cf5d22fdfd0ed4975",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -361,7 +363,7 @@
         "ara",
         "ckb"
     ],
-    "wof:lastmodified":1690934364,
+    "wof:lastmodified":1695884513,
     "wof:name":"Babil",
     "wof:parent_id":85632191,
     "wof:placetype":"region",

--- a/data/890/445/289/890445289.geojson
+++ b/data/890/445/289/890445289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147254,
-    "geom:area_square_m":1450388506.682915,
+    "geom:area_square_m":1450388457.891615,
     "geom:bbox":"42.349622,37.015039,43.182542,37.381556",
     "geom:latitude":37.197394,
     "geom:longitude":42.835191,
@@ -215,7 +215,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8b7baa460c6f6be7535b09364c75e6d",
+    "wof:geomhash":"0273e237d9ef7ce801349e88fe6409c7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -225,7 +225,7 @@
         }
     ],
     "wof:id":890445289,
-    "wof:lastmodified":1690934388,
+    "wof:lastmodified":1695886620,
     "wof:name":"Zakho",
     "wof:parent_id":85672417,
     "wof:placetype":"county",

--- a/data/890/445/493/890445493.geojson
+++ b/data/890/445/493/890445493.geojson
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":890445493,
-    "wof:lastmodified":1694492676,
+    "wof:lastmodified":1695886687,
     "wof:name":"Koisnjaq",
     "wof:parent_id":85672425,
     "wof:placetype":"county",

--- a/data/890/445/495/890445495.geojson
+++ b/data/890/445/495/890445495.geojson
@@ -104,7 +104,7 @@
         }
     ],
     "wof:id":890445495,
-    "wof:lastmodified":1694492677,
+    "wof:lastmodified":1695886689,
     "wof:name":"Soran",
     "wof:parent_id":85672425,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.